### PR TITLE
fix: Changed the typings of `createNodeFromJSON` . 

### DIFF
--- a/src/modules/createNode.ts
+++ b/src/modules/createNode.ts
@@ -207,7 +207,7 @@ function _createNode (peerInfo: any, cb: any) {
 }
 
 export function createWebNodeFromJSON (
-  nodeJSONObj: Record<string, any>,
+  nodeJSONObj: any,
   callback: (arg0: Error | undefined, arg1: PeerId) => void
 ) {
   let node: any


### PR DESCRIPTION
This should be reviewed, but at least the node now compiles. No idea why the previous merge caused this